### PR TITLE
Do not try to access highlighted attributes without checking if they exist

### DIFF
--- a/front/assets/scripts/predictions.js
+++ b/front/assets/scripts/predictions.js
@@ -21,12 +21,12 @@ var mvnAlgoliaPrediction = (function($) {
 						data[i] = {
 									label: hit.title,
 									value: hit.title,
-									title: hit._highlightResult.title.value,
+									title: (hit._highlightResult.title && hit._highlightResult.title.value) || hit.title,
 									permalink: hit.permalink,
 									categories: hit.category,
 									tags: hit._tags,
-									excerpt: hit._highlightResult.excerpt.value,
-									description: hit._highlightResult.content.value,
+									excerpt: (hit._highlightResult.excerpt && hit._highlightResult.excerpt.value) || hit.excerpt,
+									description: (hit._highlightResult.content && hit._highlightResult.content.value) || hit.content,
 									date: hit.date,
 									featuredImage: hit.featuredImage
 									};


### PR DESCRIPTION
The JS code was accessing an undefined `excerpt` attribute (`excerpt` is not highlighted, because I didn't include it in the `attributesToIndex` list):

``` json
{
  "attributesToIndex":["title","unordered(content)"],
  "customRanking":["desc(modified)"]
} 
```
